### PR TITLE
Bug  test find a substitut

### DIFF
--- a/substitut_search/tests/tests_views.py
+++ b/substitut_search/tests/tests_views.py
@@ -27,13 +27,21 @@ class TestSearchProduct(TestCase):
             len(response.context["products"]),
             min(len(Product.objects.all()), NB_DISPLAYED_PRODUCTS))
 
-    # test if the founded substitut has a better nutriscore
+    # test if the substituts have a better nutriscore and share a category
     def test_find_a_substitut(self):
-        product = Product.objects.filter(categories__contains=["en:biscuits"]).filter(nutriscore="c")[0]
+        product = Product.objects \
+                        .filter(categories__contains=["en:biscuits"]) \
+                        .filter(nutriscore="d")[0]
         response = self.client.get(
             f"{reverse('substitut:find')}?product_id={product.pk}")
-        self.assertLess(
-            response.context['products'][0].nutriscore, product.nutriscore)
+        for substitut in response.context['products']:
+            self.assertLess(substitut.nutriscore, product.nutriscore)
+            for category in substitut.categories:
+                if category in product.categories:
+                    break
+            else:
+                self.fail("A substitut doesn't share any"
+                          " category with the initial product")
 
 class TestProductPage(TestCase):
     fixtures = ['2products']

--- a/substitut_search/tests/tests_views.py
+++ b/substitut_search/tests/tests_views.py
@@ -29,7 +29,7 @@ class TestSearchProduct(TestCase):
 
     # test if the founded substitut has a better nutriscore
     def test_find_a_substitut(self):
-        product = Product.objects.all()[0]
+        product = Product.objects.filter(categories__contains=["en:biscuits"]).filter(nutriscore="c")[0]
         response = self.client.get(
             f"{reverse('substitut:find')}?product_id={product.pk}")
         self.assertLess(


### PR DESCRIPTION
Substitut_search:

1. Fix of a bug in the test "test_find_a_substitut" in "tests_views". This test used to take as initial product the first product of the database, and search a substitute to it. That worked with the old data fixture, but with the new fixture "19products", the first product of the database is the only product of its categories. Therefore, the program couldn't find a substitute to this product.
To fix this, the test now takes a product with the category "biscuits" and with a nutriscore of "d" as initial product, because we know there is in the database products with the category "biscuits" and a better nutriscore.

2. Update of the same test. The test used to only check if the first of the founded substituts has a better nutriscore that the initial product. This was partly because there was only two products in the data fixture. Now that the fixture contains more products, we can check that every founded substituts have a better nutriscore that the initial product, and  share at least one category with the initial product. As the fixture "19products" contains products with worse nutriscore or from a different category, we can really test that the program doesn't show the wrong substituts.
